### PR TITLE
Add compensation sensors for improved internal sensor calculations

### DIFF
--- a/ultimatesensor-mini-v1/ultimatesensor-mini-basic.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-basic.yaml
@@ -233,12 +233,16 @@ sensor:
     address: 0x23
     update_interval: 60s
 
-  # SGP40
+  # SGP41
   - platform: sgp4x
+    id: sgp41
     voc:
       name: "VOC Index"
     nox:
       name: "NOx Index"
+    compensation:
+      humidity_source: scd41_humidity
+      temperature_source: scd41_temperature
 
   # LD2450
   - platform: template

--- a/ultimatesensor-mini-v1/ultimatesensor-mini-complete.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-complete.yaml
@@ -233,12 +233,16 @@ sensor:
     address: 0x23
     update_interval: 60s
 
-  # SGP40
+  # SGP41
   - platform: sgp4x
+    id: sgp41
     voc:
       name: "VOC Index"
     nox:
       name: "NOx Index"
+    compensation:
+      humidity_source: scd41_humidity
+      temperature_source: scd41_temperature
 
   # SPS30 (For complete version)
   - platform: sps30


### PR DESCRIPTION
Added compensation sensors for the sgp41 voc/nox sensor.
See esphome docs for more info: https://esphome.io/components/sensor/sgp4x.html#example-with-compensation

The SCD41 temp en humidity sensors can be used by the SGP41 sensor to improve voc/nox calculations.