### PR TITLE
Update ultimatesensor-mini-basic.yaml

### DIFF
--- a/ultimatesensor-mini-v1/ultimatesensor-mini-basic.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-basic.yaml
@@ -191,6 +191,7 @@ light:
     chipset: ws2812
     name: "Back light"
     id: rgb_back_light
+    rmt_symbols: 96
   #WS2812 LED at the front
   - platform: esp32_rmt_led_strip
     rgb_order: GRB
@@ -199,6 +200,7 @@ light:
     chipset: ws2812
     name: "Front light"
     id: rgb_front_light
+    rmt_symbols: 96
 
 
 # Status LED of ESP

--- a/ultimatesensor-mini-v1/ultimatesensor-mini-basic.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-basic.yaml
@@ -188,7 +188,6 @@ light:
     rgb_order: GRB
     pin: GPIO20
     num_leds: 1
-    rmt_channel: 0
     chipset: ws2812
     name: "Back light"
     id: rgb_back_light
@@ -197,7 +196,6 @@ light:
     rgb_order: GRB
     pin: GPIO05
     num_leds: 1
-    rmt_channel: 1
     chipset: ws2812
     name: "Front light"
     id: rgb_front_light

--- a/ultimatesensor-mini-v1/ultimatesensor-mini-complete.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-complete.yaml
@@ -192,6 +192,7 @@ light:
     chipset: ws2812
     name: "Back light"
     id: rgb_back_light
+    rmt_symbols: 96
   #WS2812 LED at the front
   - platform: esp32_rmt_led_strip
     rgb_order: GRB
@@ -201,6 +202,7 @@ light:
     chipset: ws2812
     name: "Front light"
     id: rgb_front_light
+    rmt_symbols: 96
 
 
 # Status LED of ESP


### PR DESCRIPTION
Only for Arduino platforms (and ESP-IDF <5 which was used until ESPHome 2025), the RMT channel must be defined.

So removed from the configuration.