### PR TITLE
Update ultimatesensor-mini-complete.yaml

### DIFF
--- a/ultimatesensor-mini-v1/ultimatesensor-mini-complete.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-complete.yaml
@@ -188,7 +188,6 @@ light:
     rgb_order: GRB
     pin: GPIO20
     num_leds: 1
-    rmt_channel: 0
     chipset: ws2812
     name: "Back light"
     id: rgb_back_light
@@ -198,7 +197,6 @@ light:
     rgb_order: GRB
     pin: GPIO05
     num_leds: 1
-    rmt_channel: 1
     chipset: ws2812
     name: "Front light"
     id: rgb_front_light


### PR DESCRIPTION
Removed rmt_channel: 0 because it caused an error when updating