### PR TITLE
Replace targetx_active = true with a distance-based check 

### DIFF
--- a/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
@@ -598,21 +598,21 @@ uart:
           }
 
           int zone1_count = 0;      
-          if (id(target1_active).state == true ) {
+          if (id(target1_distance).state != 0 ) {
               if ((id(target1_x).state >= id(zone1_begin_x).state && id(target1_x).state <= id(zone1_end_x).state) &&
                   (id(target1_y).state >= id(zone1_begin_y).state && id(target1_y).state <= id(zone1_end_y).state)) {
                   zone1_count++;
               }
           }
 
-          if (id(target2_active).state == true ) {
+          if (id(target2_distance).state != 0 ) {
               if ((id(target2_x).state >= id(zone1_begin_x).state && id(target2_x).state <= id(zone1_end_x).state) &&
                   (id(target2_y).state >= id(zone1_begin_y).state && id(target2_y).state <= id(zone1_end_y).state)) {
                   zone1_count++;
               }
           }
 
-          if (id(target3_active).state == true ) {
+          if (id(target3_distance).state != 0 ) {
               if ((id(target3_x).state >= id(zone1_begin_x).state && id(target3_x).state <= id(zone1_end_x).state) &&
                   (id(target3_y).state >= id(zone1_begin_y).state && id(target3_y).state <= id(zone1_end_y).state)) {
                   zone1_count++;
@@ -628,19 +628,19 @@ uart:
           }
 
           int zone2_count = 0;
-          if (id(target1_active).state == true ) {
+          if (id(target1_distance).state != 0 ) {
               if ((id(target1_x).state >= id(zone2_begin_x).state && id(target1_x).state <= id(zone2_end_x).state) &&
                   (id(target1_y).state >= id(zone2_begin_y).state && id(target1_y).state <= id(zone2_end_y).state)) {
                   zone2_count++;
               }
           }
-          if (id(target2_active).state == true ) {
+          if (id(target2_distance).state != 0 ) {
               if ((id(target2_x).state >= id(zone2_begin_x).state && id(target2_x).state <= id(zone2_end_x).state) &&
                   (id(target2_y).state >= id(zone2_begin_y).state && id(target2_y).state <= id(zone2_end_y).state)) {
                   zone2_count++;
               }
           }
-          if (id(target3_active).state == true ) {
+          if (id(target3_distance).state != 0 ) {
               if ((id(target3_x).state >= id(zone2_begin_x).state && id(target3_x).state <= id(zone2_end_x).state) &&
                   (id(target3_y).state >= id(zone2_begin_y).state && id(target3_y).state <= id(zone2_end_y).state)) {
                   zone2_count++;
@@ -655,19 +655,19 @@ uart:
           }
 
           int zone3_count = 0;
-          if (id(target1_active).state == true ) {
+          if (id(target1_distance).state != 0 ) {
               if ((id(target1_x).state >= id(zone3_begin_x).state && id(target1_x).state <= id(zone3_end_x).state) &&
                   (id(target1_y).state >= id(zone3_begin_y).state && id(target1_y).state <= id(zone3_end_y).state)) {
                   zone3_count++;
               }
           }
-          if (id(target2_active).state == true ) {
+          if (id(target2_distance).state != 0 ) {
               if ((id(target2_x).state >= id(zone3_begin_x).state && id(target2_x).state <= id(zone3_end_x).state) &&
                   (id(target2_y).state >= id(zone3_begin_y).state && id(target2_y).state <= id(zone3_end_y).state)) {
                   zone3_count++;
               }
           }
-          if (id(target3_active).state == true ) {
+          if (id(target3_distance).state != 0 ) {
               if ((id(target3_x).state >= id(zone3_begin_x).state && id(target3_x).state <= id(zone3_end_x).state) &&
                   (id(target3_y).state >= id(zone3_begin_y).state && id(target3_y).state <= id(zone3_end_y).state)) {
                   zone3_count++;
@@ -682,19 +682,19 @@ uart:
           }
 
           int zone4_count = 0;
-          if (id(target1_active).state == true ) {
+          if (id(target1_distance).state != 0 ) {
               if ((id(target1_x).state >= id(zone4_begin_x).state && id(target1_x).state <= id(zone4_end_x).state) &&
                   (id(target1_y).state >= id(zone4_begin_y).state && id(target1_y).state <= id(zone4_end_y).state)) {
                   zone4_count++;
               }
           }
-          if (id(target2_active).state == true ) {
+          if (id(target2_distance).state != 0 ) {
               if ((id(target2_x).state >= id(zone4_begin_x).state && id(target2_x).state <= id(zone4_end_x).state) &&
                   (id(target2_y).state >= id(zone4_begin_y).state && id(target2_y).state <= id(zone4_end_y).state)) {
                   zone4_count++;
               }
           }
-          if (id(target3_active).state == true ) {
+          if (id(target3_distance).state != 0 ) {
               if ((id(target3_x).state >= id(zone4_begin_x).state && id(target3_x).state <= id(zone4_end_x).state) &&
                   (id(target3_y).state >= id(zone4_begin_y).state && id(target3_y).state <= id(zone4_end_y).state)) {
                   zone4_count++;


### PR DESCRIPTION
While you set distance/target_x/target_y to 0 when p1_distance > max_distance (see line 552). It does not set p1_active to false immedialty. It first increase the zone_count++ (because p1 is active and x,y values are 0, which can be inside a zone -> line 601). 
I replace targetx_active = true with a distance-based check (distance != 0) to fix the issue where zone_count incorrectly becomes 1 for a single cycle while the target is still active and x,y values are 0.

