### PR TITLE
fix: Switch LED strips from neopixelbus to esp32_rmt_led_strip with rmt_symbols: 48

### DIFF
--- a/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
@@ -222,18 +222,20 @@ i2c:
 
 light:
   - platform: esp32_rmt_led_strip
-    chipset: WS2812
+    rgb_order: GRB
     pin: GPIO20
     num_leds: 1
-    rgb_order: GRB
+    chipset: WS2812
+    rmt_symbols: 48
     name: "Back light"
     id: rgb_back_light
 
   - platform: esp32_rmt_led_strip
-    chipset: WS2812
+    rgb_order: GRB
     pin: GPIO5
     num_leds: 1
-    rgb_order: GRB
+    chipset: WS2812
+    rmt_symbols: 48
     name: "Front light"
     id: rgb_front_light
 


### PR DESCRIPTION
On ESP32-S3, using two neopixelbus instances with esp32_rmt caused a conflict: neopixelbus uses the legacy ESP-IDF v4 RMT API (rmt_channel_t enum) while esp32_rmt_led_strip uses the new ESP-IDF v5 API (rmt_channel_t struct pointer), causing a type conflict at compile time.

With two esp32_rmt_led_strip instances using the default rmt_symbols: 64, the RMT symbol memory pool on ESP32-S3 (4 channels × 48 symbols = 192 total) is exhausted: each strip requests 2 blocks (64 > 48 per block), leaving no valid handle for the second strip, resulting in RMT TX timeout.

Setting rmt_symbols: 48 (one block per strip, 24 symbols needed for a single WS2812 LED) resolves both issues. Verified on ESP32-S3 hardware.

See: https://github.com/esphome/esphome/issues/9666