### PR TITLE
fix: update play_stream script to use renamed media_player id

### DIFF
--- a/ultimatesensor-mini-v1/beta-ultimatesensor-mini-complete.yaml
+++ b/ultimatesensor-mini-v1/beta-ultimatesensor-mini-complete.yaml
@@ -70,11 +70,11 @@ script:
   - id: play_stream
     then:
       - media_player.volume_set:  
-          id: speaker
+          id: media_player_main
           volume: 50%
       # Play boot sound
       - media_player.play_media:
-          id: speaker
+          id: media_player_main
           media_url: "https://smarthomeshop.io/products/ultimatesensor-mini/v1/audio/boot1.mp3"
       # Wait 3 seconds to load media
       - delay: 3s

--- a/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
@@ -63,11 +63,11 @@ script:
   - id: play_stream
     then:
       - media_player.volume_set:  
-          id: speaker
+          id: media_player_main
           volume: 50%
       # Play boot sound
       - media_player.play_media:
-          id: speaker
+          id: media_player_main
           media_url: "https://smarthomeshop.io/products/ultimatesensor-mini/v1/audio/boot1.mp3"
       # Wait 3 seconds to load media
       - delay: 3s


### PR DESCRIPTION
## Problem
ESPHome 2026.4.0 reserves `speaker` as an integration name. A previous fix renamed the `media_player` id from `speaker` to `media_player_main`, but the `play_stream` script was not updated and still references the old id, causing a build failure:

```
ID 'speaker' conflicts with the name of an esphome integration, please use another ID name.
```

## Fix
Updated `media_player.volume_set` and `media_player.play_media` actions in the `play_stream` script to use `id: media_player_main` in both `ultimatesensor-mini-common.yaml` and `beta-ultimatesensor-mini-complete.yaml`.