### PR TITLE
Fix speaker codec support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog starts on 2026-04-21. Earlier firmware versions existed before th
 
 ## [Unreleased]
 
-- Add customer-facing firmware notes here before merging a PR.
+- Fix boot audio playback by compiling all speaker media player codecs.
 
 ## [UltimateSensor Mini Beta V1 2.35-beta.36] - 2026-04-21
 

--- a/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
+++ b/ultimatesensor-mini-v1/ultimatesensor-mini-common.yaml
@@ -157,6 +157,7 @@ media_player:
   - platform: speaker
     id: media_player_main
     name: US Mini Media Player
+    codec_support_enabled: ALL
     announcement_pipeline:
       speaker: i2s_speaker_output
       num_channels: 1


### PR DESCRIPTION
## What changed

- Compile all speaker media player codecs with `codec_support_enabled: ALL`.
- Update the changelog with a customer-facing boot audio playback fix.

## Why

The boot sound is served as MP3 while the configured announcement pipeline prefers FLAC. With codec support limited to needed pipeline codecs, MP3 playback can fail with `ESP_ERR_NOT_SUPPORTED`.

## Validation

- Checked the staged diff only includes the codec option and changelog entry.
- Ran `git diff --cached --check` before committing.
- GitHub Actions started validation for the firmware variants.
